### PR TITLE
fetch query lp data with create at

### DIFF
--- a/momenttrack_shared_services/actions/move.py
+++ b/momenttrack_shared_services/actions/move.py
@@ -359,7 +359,7 @@ class Move:
                     )
                 line_item = ProductionOrderLineitem.query.filter_by(
                     license_plate_id=entity.id
-                ).first()
+                ).order_by(ProductionOrderLineitem.created_at.desc()).first()
 
                 if line_item:
                     dest_loc = LocationSchema().dump(


### PR DESCRIPTION
while quering for lp data from production order lineitems could not fetch latest data. so added order by with created at to fetch the data with datetime and lp id.